### PR TITLE
Fix mud date picker validation and allow title for edit dialog

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -22,6 +22,13 @@ namespace MudBlazor
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
         /// <summary>
+        /// If true, the <see cref="OnBlurredAsync(FocusEventArgs)"/> ignores <see cref="ReadOnly"/> flag to trigger validation/onblur.
+        /// Use case for setting this to true is for component that wrap some input component (inherit <see cref="MudBaseInput{T}"/>), example <see cref="MudPicker{T}"/>.
+        /// to notify the outer component of the <see cref="OnBlur"/> event.
+        /// </summary>
+        internal bool OverrideReadOnlyOnBlur { get; set; }
+
+        /// <summary>
         /// If true, the input element will be disabled.
         /// </summary>
         [Parameter]
@@ -283,7 +290,7 @@ namespace MudBlazor
 
         protected internal virtual async Task OnBlurredAsync(FocusEventArgs obj)
         {
-            if (ReadOnly)
+            if (ReadOnly && !OverrideReadOnlyOnBlur)
                 return;
             _isFocused = false;
             

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -338,6 +338,9 @@
     </div>
     <CascadingValue Value="true" IsFixed Name="IsNested">
         <MudDialog Options="EditDialogOptions" @bind-IsVisible="isEditFormOpen">
+             <TitleContent>
+                 <MudText Typo="Typo.h6">@EditDialogTitle</MudText>
+             </TitleContent>
             <DialogContent>
                 <MudForm @ref="_editForm" FieldChanged="FormFieldChanged">
                     @foreach (var column in RenderedColumns)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -453,6 +453,11 @@ namespace MudBlazor
         [Parameter] public DialogOptions EditDialogOptions { get; set; }
 
         /// <summary>
+        /// Set the title for the edit dialog.
+        /// </summary>
+        [Parameter] public string EditDialogTitle { get; set; }
+
+        /// <summary>
         /// The data to display in the table. MudTable will render one row per item
         /// </summary>
         ///

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -12,6 +12,7 @@
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
+                                   OnBlur="@OnInternalInputBlurred"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"
                                    Clearable="Clearable"/>
                </InputContent>

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -165,6 +166,27 @@ namespace MudBlazor
         {
             return DateRange.TryParse(start, end, Converter, out var dateRange) ? dateRange : null;
         }
+        protected override async Task OnInternalInputBlurred(FocusEventArgs args)
+        {
+            if (!ReadOnly)
+            {
+                Touched = _rangeInput?.Touched ?? Touched;
+                await BeginValidateAsync();
+            }
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (firstRender)
+            {
+                if (_rangeInput is not null)
+                {
+                    _rangeInput.OverrideReadOnlyOnBlur = true;
+                }
+            }
+            base.OnAfterRender(firstRender);
+        }
+
 
         protected override void OnPickerClosed()
         {

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
 
         protected Task OnInput(ChangeEventArgs args)
         {
-            if (!Immediate && !string.IsNullOrEmpty(args?.Value as string)
+            if (!Immediate && !string.IsNullOrEmpty(args?.Value as string))
                 return Task.CompletedTask;
             _isFocused = true;
             return SetTextAsync(args?.Value as string);

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
 
         protected Task OnInput(ChangeEventArgs args)
         {
-            if (!Immediate)
+            if (!Immediate && !string.IsNullOrEmpty(args?.Value as string)
                 return Task.CompletedTask;
             _isFocused = true;
             return SetTextAsync(args?.Value as string);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -37,6 +37,7 @@
              Error="@Error" 
              ErrorText="@ErrorText"
              Clearable="@(GetReadOnlyState() ? false : Clearable)"
+             OnBlur="@OnInternalInputBlurred"
              OnClearButtonClick="@(() => Clear())"
              @onclick="OnClickAsync" />;
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -508,6 +508,10 @@ namespace MudBlazor
             if (firstRender == true)
             {
                 await EnsureKeyInterceptor();
+                if (_inputReference is not null)
+                {
+                    _inputReference.OverrideReadOnlyOnBlur = true;
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -559,6 +563,15 @@ namespace MudBlazor
         protected virtual void OnPickerClosed()
         {
             PickerClosed.InvokeAsync(this);
+        }
+
+        protected virtual async Task OnInternalInputBlurred(FocusEventArgs args)
+        {
+            if (!ReadOnly)
+            {
+                Touched = _inputReference?.Touched ?? Touched;
+                await BeginValidateAsync();
+            }
         }
 
         protected internal virtual void HandleKeyDown(KeyboardEventArgs obj)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -763,6 +763,11 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                if (_elementReference is not null)
+                {
+                    _elementReference.OverrideReadOnlyOnBlur = true;
+                }
+
                 _keyInterceptor = KeyInterceptorFactory.Create();
 
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
@@ -1073,6 +1078,12 @@ namespace MudBlazor
                 // when the menu is open we immediately get back the focus if we lose it (i.e. because of checkboxes in multi-select)
                 // otherwise we can't receive key strokes any longer
                 await FocusAsync();
+            }
+
+            if (!ReadOnly)
+            {
+                Touched = _elementReference.Touched;
+                await BeginValidateAsync();
             }
         }
 

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -160,6 +160,26 @@ namespace MudBlazor
             }
             return base.SetTextAsync(text, updateValue);
         }
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (firstRender == true)
+            {
+                if (OverrideReadOnlyOnBlur)
+                {
+                    if (InputReference is not null)
+                    {
+                        InputReference.OverrideReadOnlyOnBlur = true;
+                    }
+
+                    if (_maskReference is not null)
+                    {
+                        _maskReference.OverrideReadOnlyOnBlur = true;
+                    }
+                }
+            }
+
+            base.OnAfterRender(firstRender);
+        }
 
         private async Task OnMaskedValueChanged(string s)
         {


### PR DESCRIPTION
Fixed date picker validation bug, where basic validation was not being triggered on touch. Allowed users to specify a title for the edit dialog of MudDataGrid.
